### PR TITLE
Added Bulgaria and Updated Finnish monitoring agency

### DIFF
--- a/monitoring-agencies-information.md
+++ b/monitoring-agencies-information.md
@@ -7,12 +7,13 @@
 | :------------------- | :------------------ | :------------------------- | :------------------ | :--------------------- |
 | Austria              | ❓ Unknown          |   N/A                      | ❓ Unknown          |                        |
 | Belgium              | ❓ Unknown          |   N/A                      | ❓ Unknown          |                        |
+| Bulgaria             | ❓ Unknown          |   N/A                      | ❓ Unknown          |                        |
 | Croatia              | ❓ Unknown          |   N/A                      | ❓ Unknown          |                        |
 | Cyprus               | ❓ Unknown          |   N/A                      | ❓ Unknown          |                        |
 | Czechia              | ❓ Unknown          |   N/A                      | ❓ Unknown          |                        |
 | Denmark              | ❓ Unknown          |   N/A                      | <ul><li>Sikkerhedsstyrelsen</li><li>Energistyrelsen</li><li>Trafikstyrelsen</li><li>Søfartsstyrelsen</li></ul> | [Hvem fører kontrol med hvad i tilgængelighedsloven?](https://useit-consulting.dk/aktuelt/hvem-forer-kontrol-med-hvad-i-tilgaengelighedsloven/) |
 | Estonia              | ❓ Unknown          |   N/A                      | ❓ Unknown          |                        |
-| Finland              |  ✔️ Yes             |   [Saavutettavuusvaatimukset](https://www.saavutettavuusvaatimukset.fi/fi/digipalvelulain-vaatimukset/muutokset-digipalvelulakiin) | <ul><li>[Saavutettavuusvaatimukset](https://www.saavutettavuusvaatimukset.fi/)</li></ul> | |
+| Finland              |  ✔️ Yes             |   [Saavutettavuusvaatimukset](https://www.saavutettavuusvaatimukset.fi/fi/digipalvelulain-vaatimukset/muutokset-digipalvelulakiin) | <ul><li>[Traficom](https://www.traficom.fi/fi/traficom/esteettomyys)</li></ul> | |
 | France               | ❓ Unknown          |   N/A                      | ❓ Unknown          |                        |
 | Germany              | ❓ Unknown          |   N/A                      | Gemeinsame Marktüberwachung der Länder für die Barrierefreiheit von Produkten und Dienstleistungen (MLBF)          |                        |
 | Greece               | ❓ Unknown          |   N/A                      | ❓ Unknown          |                        |


### PR DESCRIPTION
Bulgaria was missing from the list and even though there are complications with incorporating the directive to the national law, I think it should be in the list. I wonder though if we should add the issues to the comment (https://ec.europa.eu/commission/presscorner/detail/it/ip_24_3801). 

I also updated monitoring agency for Finland as it is Traficom since 01.01.2025