### PR TITLE
Update renamed repository links

### DIFF
--- a/Accessibility Statement Template.md
+++ b/Accessibility Statement Template.md
@@ -1,7 +1,7 @@
 # Accessibility statement template
 - ⚠️ Always use HTML when possible. [PDF: Still Unfit for Human Consumption, 20 Years Later](https://www.nngroup.com/articles/pdf-unfit-for-human-consumption/).
 - 💡 There is an in-depth article [The accessibility statement at Axess Lab](https://axesslab.com/accessibility-statement-for-the-eaa).
-- 💡 Information about monitoring agencies across the EU [Table of countries under the EAA](https://github.com/Nordic-Accessibility-Community-Group/working-with-EN-301-549/blob/main/monitoring-agencies-information.md)
+- 💡 Information about monitoring agencies across the EU [Table of countries under the EAA](https://github.com/Nordic-Accessibility-Community-Group/en-301-549-resources-and-eaa-monitoring/blob/main/monitoring-agencies-information.md)
 - 💡 An implemented live version can be found at [Accessibility Cloud](https://www.accessibilitycloud.com/).
 - 💡 Tetra logical has a great article about the EAA [Understanding the European Accessibility Act (EAA), by Léonie Watson](https://tetralogical.com/blog/2025/03/19/understanding-the-eaa/)
 - [List of sites with accessibility statements](https://codeberg.org/yatil/accessibility-statements)
@@ -11,7 +11,7 @@ This accessibility statement template for the is based on the demands from the E
 The focus is on assisting the user rather than merely outlining legal requirements and shortcomings/failures. THe monitoring agencies are for the EAA referred to as market surveillance.
 
 ### What does the law say?
-It isn't currently very clear what an accessibility statement is expected to look like, many require one which you can see in the list [Table of countries under the EAA](https://github.com/Nordic-Accessibility-Community-Group/working-with-EN-301-549/blob/main/monitoring-agencies-information.md). What is clear is that you must document your accessibility compliance status and make this documentation available to your users.
+It isn't currently very clear what an accessibility statement is expected to look like, many require one which you can see in the list [Table of countries under the EAA](https://github.com/Nordic-Accessibility-Community-Group/en-301-549-resources-and-eaa-monitoring/blob/main/monitoring-agencies-information.md). What is clear is that you must document your accessibility compliance status and make this documentation available to your users.
 You need to report any known accessibility issues to the appropriate government agency for each country you're active in.
 
 You also need to describe the accessibility or inaccessibility of products in your online store.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Working with EN-301 549
-1. Use [discussions](https://github.com/Nordic-Accessibility-Community-Group/working-with-EN-301-549/discussions) for asking questions and for discussing topics.
-1. Use [issues](https://github.com/Nordic-Accessibility-Community-Group/working-with-EN-301-549/issues) only for repository changes (not for questions in general).
-2. Please use the [Accessibility statement template](https://github.com/Nordic-Accessibility-Community-Group/working-with-EN-301-549/blob/main/Accessibility%20Statement%20Template.md) for documentation needs.
-3. Here's a list of countries [monitoring agencies and accessibility requirements](https://github.com/Nordic-Accessibility-Community-Group/working-with-EN-301-549/blob/main/monitoring-agencies-information.md).
-4. [ Sites using overlays](https://github.com/Nordic-Accessibility-Community-Group/working-with-EN-301-549/blob/main/Sites%20using%20accessibility%20overlays.md).
+1. Use [discussions](https://github.com/Nordic-Accessibility-Community-Group/en-301-549-resources-and-eaa-monitoring/discussions) for asking questions and for discussing topics.
+1. Use [issues](https://github.com/Nordic-Accessibility-Community-Group/en-301-549-resources-and-eaa-monitoring/issues) only for repository changes (not for questions in general).
+2. Please use the [Accessibility statement template](https://github.com/Nordic-Accessibility-Community-Group/en-301-549-resources-and-eaa-monitoring/blob/main/Accessibility%20Statement%20Template.md) for documentation needs.
+3. Here's a list of countries [monitoring agencies and accessibility requirements](https://github.com/Nordic-Accessibility-Community-Group/en-301-549-resources-and-eaa-monitoring/blob/main/monitoring-agencies-information.md).
+4. [ Sites using overlays](https://github.com/Nordic-Accessibility-Community-Group/en-301-549-resources-and-eaa-monitoring/blob/main/Sites%20using%20accessibility%20overlays.md).
 
 ## What it is for
 1. How to understand the EN-standard and how monitoring works in different countries.
@@ -26,7 +26,7 @@ This repository was created from discussions in the W3C Nordic Community Group, 
 - [WCAG Discussions](https://github.com/w3c/wcag/discussions/categories/q-a)
 
 # Code of conduct
-1. See if your question is an open issue or already in the [Q&A](https://github.com/Nordic-Accessibility-Community-Group/working-with-EN-301-549/discussions/categories/q-a) and please try to read the standards.
+1. See if your question is an open issue or already in the [Q&A](https://github.com/Nordic-Accessibility-Community-Group/en-301-549-resources-and-eaa-monitoring/discussions/categories/q-a) and please try to read the standards.
 2. This is a safe place for discussions.
 3. We are respectful and nice to each other and everyone's opinions.
 4. If you do not agree with something, please write it in a respectful manner.


### PR DESCRIPTION
## Problem

Internal documentation linked to the repository’s former name.

## Solution

Update the README and accessibility statement template to use the renamed repository URL.