### PR TITLE
Correct interpretation of EN 301 549 clause 5.2

### DIFF
--- a/Understanding EN 301 549/5.2 Activation of Accessibility Features.md
+++ b/Understanding EN 301 549/5.2 Activation of Accessibility Features.md
@@ -2,140 +2,161 @@
 
 Status of this document: **⚠️ Draft mode.**
 
-> Normative requirement (EN 301 549 v4.1.0 draft)
+This page is the Nordic Accessibility Community Group's understanding of Final draft EN 301 549 V4.1.0 (2026-06), clause 5.2. It is meant to help readers discuss and apply the clause; it is not an official part of EN 301 549. The source is the text submitted for approval vote, not a published standard.
 
-## Normative requirement
-"Accessibility features shall be discoverable and operable without requiring assistance from another person or requiring interaction methods that are not independently operable using assistive technologies or alternative input modalities."
+## In Brief
+
+### Goal
+
+A documented accessibility feature can be activated using a method that supports the need the feature is intended to meet.
+
+### What to do
+
+For each documented accessibility feature needed for a specific accessibility need, provide an activation path that does not depend on a method that fails to support that same need.
+
+### Why it matters
+
+An accessibility feature cannot meet its purpose if the only way to turn it on depends on an ability that the feature is intended to compensate for.
+
+## Requirement in Context
+
+The official source is [Final draft EN 301 549 V4.1.0 (2026-06)](https://www.etsi.org/deliver/etsi_EN/301500_301599/301549/04.01.00_30/en_301549v040100va.pdf), clause 5.2 on page 35 and Annex C.5.2 on page 149.
+
+In practical terms, clause 5.2 applies when ICT includes documented accessibility features. A documented feature that is required to meet a specific need has to be activatable without relying on a method that does not support that need.
+
+The draft defines a documented accessibility feature as a feature offered to end users that can enhance accessibility and is documented.
 
 ## Scope
-This clause applies to all user-facing accessibility features provided within ICT products and services.
 
+The clause applies when ICT includes documented accessibility features. The activation of each applicable feature is assessed in relation to the specific need that feature is required to meet.
 
-## Intent
-The intent of this requirement is to ensure that accessibility features are **practically usable in real-world conditions**, not just technically present.
+Clause 5.2 does not itself establish:
 
-Many ICT products provide accessibility-related functionality (such as screen reader support, text resizing, captions, or contrast adjustments), but these fail in practice when users cannot locate or activate them independently.
+- which accessibility features have to be documented
+- a general discoverability requirement
+- a requirement for an accessibility settings area
+- a requirement for multiple independent activation methods
+- a requirement to support every input modality
+- a requirement that every feature be activated through assistive technology
+- a general requirement to present every accessibility feature during onboarding or first use
 
-This requirement addresses barriers such as:
+Some of these outcomes may be required by other applicable clauses, or may be good practice. They should not be presented as requirements of clause 5.2 itself.
 
-- Accessibility settings hidden within complex or non-intuitive navigation structures
-- Features requiring sighted assistance to activate
-- Reliance on interaction methods that are not operable via assistive technologies or alternative input modalities (e.g., gesture-only activation without keyboard or assistive technology equivalent)
-- Lack of discoverability for users requiring accessibility features at first use or during urgent need
+## Practical Effect
 
-**This ensures accessibility features are usable at the time they are required by the user.**
+The activation method has to be considered against the same need that the feature is intended to meet. A method can support one need and fail to support another.
 
+One activation method can be sufficient when it supports the relevant need. If a feature is required to meet more than one need, assess each need separately. More than one activation method may be necessary when no single method supports all the relevant needs, but clause 5.2 does not require multiple methods as an end in itself.
 
-## Requirement
-Where a product or service provides accessibility features or settings, those features shall be:
+Assess the complete activation path, including any prerequisite, sign-in step, setup screen, confirmation, or onboarding step. If a required step relies on a method that does not support the relevant need, the activation path does not satisfy clause 5.2 for that need.
 
-- discoverable
-- operable
-- accessible via assistive technologies
-
-**without requiring assistance from another person or requiring interaction methods that are not independently operable using assistive technologies or alternative input modalities**.
-
-Activation of each accessibility feature shall be possible using **at least one interaction method that is not limited to a single sensory channel or a single input modality**.
-
-
-## This requirement benefits
-This requirement benefits a broad range of users, including:
-
-### Sensory disabilities
-- Blind and low vision users relying on screen readers or magnification.
-- Deaf and hard of hearing users requiring captions or visual alerts.
-
-### Motor disabilities
-- Users with motor impairments who rely on keyboard navigation, switches, or voice control.
-
-### Cognitive and neurological disabilities
-- Users requiring simplified interfaces or reduced motion settings.
-
-### Situational or temporary impairments
-- Injury (temporary loss of mobility or vision)
-- Environmental conditions (bright sunlight, noisy environments, one-handed use)
-
-### Older users
-- Users with age-related changes in vision, hearing, or motor ability
-
+The supporting method does not have to use assistive technology. It can be a built-in control, shortcut, voice command, hardware control, or another method, provided that the method supports the relevant need and meets other applicable requirements.
 
 ## Examples
 
-### Good examples
-- A clearly labeled **Accessibility section in system settings directly accessible from primary navigation or system settings entry points**
-- A setup wizard that prompts users to enable high contrast or screen reader support during first use
-- Keyboard-accessible toggle for captions available in media players
-- Voice assistant command that directly enables a screen reader without requiring visual confirmation steps
-- Persistent accessibility shortcut (e.g., triple-tap or shortcut key) that is documented and operable without vision
+### Screen reader
 
-### Problematic examples
-- Accessibility features located only in developer menus, making them undiscoverable through standard user interface navigation
-- Screen reader support requiring gesture-only activation without equivalent keyboard or assistive technology alternatives
-- High contrast mode hidden in unrelated settings without explicit labeling or grouping as an accessibility feature
-- Features requiring external login or support intervention to enable
-- Accessibility settings only discoverable through visually-dependent onboarding flows
+A documented built-in screen reader is required to meet a need related to use without vision.
 
+- A tactilely identifiable shortcut with speech feedback can provide an activation method that supports that need.
+- A visual settings screen as the only activation method does not support that need.
 
-## Evaluation methods
-Evaluation determines whether accessibility features can be located, understood, and activated independently by users with disabilities, including users relying on assistive technologies.
+Clause 5.2 does not require both a shortcut and a voice command if one activation path already supports the need.
 
-Assessment includes:
+### Captions
 
-- Discoverability of accessibility settings and features
-- Operability of activation controls via assistive technologies
-- Independence of activation (no external human assistance required)
-- Consistency across platforms (web, mobile, desktop)
-- Availability of equivalent activation methods across input modalities
-- Ability to activate accessibility features using assistive technology alone
-- Repeatability of activation across sessions and entry points without loss of access path.
+A documented caption feature is required to meet a need related to use without hearing.
 
+- A visible, operable caption control can provide an activation method that supports that need.
+- An audio-only menu that has to be heard to find and activate captions does not support that need.
 
-### Failures
-A product fails this requirement when:
+### Voice control
 
-- Accessibility features cannot be reached using assistive technologies (e.g., screen reader focus cannot access settings)
-- Activation requires sighted assistance or external human support
-- Features are hidden behind non-accessible onboarding or tutorial flows
-- Activation requires a single interaction method without equivalent alternative methods
-- Accessibility settings are not explicitly identified, labeled, or grouped as accessibility-related functionality
-- Critical accessibility features require third-party installation or external configuration
+A documented voice-control feature is required to meet a need related to limited manipulation or strength.
 
+- A spoken command can provide an activation method that supports that need.
+- A precise multi-finger gesture as the only activation method does not support a need that prevents the user from performing that gesture.
 
-### Passing techniques
-A product meets this requirement when:
+### One feature serving different needs
 
-- An accessibility settings area is clearly labeled and directly accessible from primary navigation or system settings
-- All accessibility features are reachable via keyboard and assistive technologies
-- Multiple independent activation methods are provided (e.g., settings menu, shortcuts, voice control)
-- Accessibility shortcuts are documented and consistently available across the product
-- Onboarding flows do not prevent or delay activation of accessibility features
-- Accessibility functions are consistently labeled using uniform terminology across the product
+Suppose a documented feature is required to meet both a limited-vision need and a limited-manipulation need. A small visual control might support neither need. A keyboard shortcut might support the limited-vision need but not a user who cannot operate a keyboard. The evaluator has to determine whether there is a supporting activation path for each relevant need. This can require different paths, but only because the needs differ.
 
+## Evaluation Methods
 
-### Testing methods
-Testing includes:
+Annex C is normative. C.5.2 specifies inspection and contains one check: determine whether the accessibility features can be activated without relying on a method that does not support the relevant need.
 
-- Navigating the interface using screen reader only
-- Navigating using keyboard only (no mouse or touch input)
-- Verifying accessibility feature discoverability from first interaction
-- Checking availability of alternative activation methods (keyboard, voice, gesture)
-- Reviewing onboarding and setup flows for accessibility barriers
-- Confirming consistency across devices and platforms
-- Attempting activation without prior knowledge of system structure
-- Verifying that activation does not require sighted assistance
-- Verifying equivalent activation across input modalities
-- Verifying that all accessibility features can be discovered and activated using assistive technology navigation alone without visual inspection
+### Preconditions
 
+The requirement applies when the ICT includes documented accessibility features.
 
-### Key Terms
-**Accessibility features:** Functionalities that support users with disabilities, such as screen readers, captions, zoom, or input alternatives.
+If the ICT does not include documented accessibility features, Annex C.5.2 marks the requirement as not applicable.
 
-**Activation:** The process of enabling or turning on a feature.
+### Procedure
 
-**Discoverability:** The ease with which users can find a feature without prior knowledge.
+A practical way to carry out the Annex C inspection is to:
 
-**Assistive technology:** External tools such as screen readers, switch devices, or voice control systems.
+1. Identify the documented accessibility features included in the ICT.
+2. Identify the specific need each feature is required to meet.
+3. Identify every step needed to activate each feature.
+4. Check whether at least one complete activation path avoids methods that do not support the relevant need.
+5. Repeat the assessment for each relevant need when a feature is required to meet more than one need.
 
-**Independent use:** The ability to complete a task without assistance from another person or external human intervention.
+### Pass
 
-**Input modality:** The method used to interact with a system (e.g., keyboard, touch, voice).
+The ICT passes when each applicable feature can be activated through at least one complete path that supports the specific need being assessed.
+
+### Fail
+
+The ICT fails when every available activation path for an applicable feature relies on a method that does not support the specific need being assessed.
+
+Examples include:
+
+- a screen reader for use without vision that can be activated only through a visual interface
+- captions for use without hearing that can be activated only through an audio-only menu
+- voice control for a limited-manipulation need that can be activated only with a gesture the intended user cannot perform
+- a supporting activation control that can be reached only after completing an earlier step that does not support the same need
+
+## Relationship to Other Requirements
+
+Clause 5.2 should be assessed alongside other applicable requirements rather than used as a substitute for them. For example:
+
+- clause 7.3 contains specific requirements for user control of audiovisual accessibility features
+- clauses 9, 10, and 11 contain requirements that may apply to the interface and controls used for activation
+- clause 11.6.1 addresses user control of documented platform accessibility features
+- clause 12.3 addresses information about accessibility features and how to use them when its precondition is met
+
+An activation path can therefore satisfy clause 5.2 and still fail another applicable requirement.
+
+## Key Terms
+
+**Documented accessibility feature:** A feature offered to end users that can enhance accessibility and is documented.
+
+**Specific need:** The accessibility need that the documented feature is required to meet. Clause 5.2 does not define this phrase separately.
+
+**Activation method:** The control, interaction, or sequence of steps used to turn on an accessibility feature.
+
+**Supporting activation path:** A complete activation path that does not depend on a method that fails to support the specific need being assessed.
+
+## Interpretation Notes
+
+### One method, not multiple methods by default
+
+The requirement is outcome-based: activation has to be possible through a method that supports the relevant need. Neither clause 5.2 nor C.5.2 sets a minimum number greater than one or requires equivalent keyboard, touch, gesture, and voice methods.
+
+Providing several activation methods can be useful and may be necessary for a feature that serves different needs. It is not, by itself, the conformance criterion in clause 5.2.
+
+### Discoverability, assistance, and assistive technology
+
+Clause 5.2 does not use the terms discoverable, independent use, assistance from another person, or assistive technology. Annex C.5.2 does not add separate checks for those concepts.
+
+This does not mean those considerations are unimportant. Other requirements can apply, and an activation path that a person cannot operate because of the relevant need does not become supporting merely because it exists. The point is narrower: these concepts should not be stated as independent requirements of clause 5.2 without another basis in the standard.
+
+### Difference from EN 301 549 V3.2.1
+
+[EN 301 549 V3.2.1](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf) contains the same core activation rule in clause 5.2 on page 28 and C.5.2 on page 120. V4.1.0 changes the opening condition from ICT that "has" documented accessibility features to ICT that "includes" them. It also adds a definition of documented accessibility feature. The Annex C procedure remains substantively the same.
+
+The normative quotation previously shown on this page appears in neither V3.2.1 nor the June 2026 V4.1.0 approval-vote draft.
+
+### Meaning of documented
+
+The meaning of documented was raised during development of V4.1.0 in [ETSI work item #431](https://labs.etsi.org/rep/HF/en301549/-/issues/431). V4.1.0 adds the defined term documented accessibility feature, but the definition still does not prescribe a particular documentation format or level of detail.


### PR DESCRIPTION
## Problem

The existing page labels a sentence about discoverability, human assistance, assistive technology, and alternative input modalities as the normative requirement. That sentence appears in neither [Final draft EN 301 549 V4.1.0 (2026-06)](https://www.etsi.org/deliver/etsi_EN/301500_301599/301549/04.01.00_30/en_301549v040100va.pdf) nor [EN 301 549 V3.2.1](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf).

Clause 5.2 instead relates each documented accessibility feature to the specific need it is required to meet. Annex C.5.2 contains one inspection: whether activation avoids a method that does not support that need. It does not add separate tests for discoverability, multiple activation methods, or assistive-technology operation. Those broader claims make several conclusions on the page stronger than clause 5.2 supports.

The June 2026 draft also defines documented accessibility feature following the ambiguity raised in [ETSI work item #431](https://labs.etsi.org/rep/HF/en301549/-/issues/431).

## Solution

Replace the unsupported quotation with a source-linked paraphrase based on clause 5.2 and C.5.2. Rebuild the scope, examples, and inspection guidance around the relationship between an activation method and the specific need being assessed.

Clarify that one supporting activation path can be sufficient, while different paths may be necessary when a feature serves different needs. Separate clause 5.2 from related requirements concerning interface accessibility, platform feature control, documentation, and audiovisual controls.