### PR TITLE
Align clause 5.2 with the agreed document structure

### DIFF
--- a/Understanding EN 301 549/5.2 Activation of Accessibility Features.md
+++ b/Understanding EN 301 549/5.2 Activation of Accessibility Features.md
@@ -18,13 +18,31 @@ For each documented accessibility feature needed for a specific accessibility ne
 
 An accessibility feature cannot meet its purpose if the only way to turn it on depends on an ability that the feature is intended to compensate for.
 
-## Requirement in Context
+## Requirement from Final Draft EN 301 549 V4.1.0
 
 The official source is [Final draft EN 301 549 V4.1.0 (2026-06)](https://www.etsi.org/deliver/etsi_EN/301500_301599/301549/04.01.00_30/en_301549v040100va.pdf), clause 5.2 on page 35 and Annex C.5.2 on page 149.
 
-In practical terms, clause 5.2 applies when ICT includes documented accessibility features. A documented feature that is required to meet a specific need has to be activatable without relying on a method that does not support that need.
+> **Plain-language summary:** Clause 5.2 applies when ICT includes documented accessibility features. A documented feature that is required to meet a specific need has to be activatable without relying on a method that does not support that need.
 
 The draft defines a documented accessibility feature as a feature offered to end users that can enhance accessibility and is documented.
+
+## Intent
+
+The activation method has to be considered against the same need that the feature is intended to meet. A method can support one need and fail to support another.
+
+One activation method can be sufficient when it supports the relevant need. If a feature is required to meet more than one need, assess each need separately. More than one activation method may be necessary when no single method supports all the relevant needs, but clause 5.2 does not require multiple methods as an end in itself.
+
+Assess the complete activation path, including any prerequisite, sign-in step, setup screen, confirmation, or onboarding step. If a required step relies on a method that does not support the relevant need, the activation path does not satisfy clause 5.2 for that need.
+
+The supporting method does not have to use assistive technology. It can be a built-in control, shortcut, voice command, hardware control, or another method, provided that the method supports the relevant need and meets other applicable requirements.
+
+## Benefits
+
+People who benefit include:
+
+- people who need to activate a screen reader without relying on vision
+- people who need to activate captions without relying on hearing
+- people who need to activate voice control without relying on a gesture they cannot perform
 
 ## Scope
 
@@ -41,16 +59,6 @@ Clause 5.2 does not itself establish:
 - a general requirement to present every accessibility feature during onboarding or first use
 
 Some of these outcomes may be required by other applicable clauses, or may be good practice. They should not be presented as requirements of clause 5.2 itself.
-
-## Practical Effect
-
-The activation method has to be considered against the same need that the feature is intended to meet. A method can support one need and fail to support another.
-
-One activation method can be sufficient when it supports the relevant need. If a feature is required to meet more than one need, assess each need separately. More than one activation method may be necessary when no single method supports all the relevant needs, but clause 5.2 does not require multiple methods as an end in itself.
-
-Assess the complete activation path, including any prerequisite, sign-in step, setup screen, confirmation, or onboarding step. If a required step relies on a method that does not support the relevant need, the activation path does not satisfy clause 5.2 for that need.
-
-The supporting method does not have to use assistive technology. It can be a built-in control, shortcut, voice command, hardware control, or another method, provided that the method supports the relevant need and meets other applicable requirements.
 
 ## Examples
 
@@ -116,17 +124,6 @@ Examples include:
 - voice control for a limited-manipulation need that can be activated only with a gesture the intended user cannot perform
 - a supporting activation control that can be reached only after completing an earlier step that does not support the same need
 
-## Relationship to Other Requirements
-
-Clause 5.2 should be assessed alongside other applicable requirements rather than used as a substitute for them. For example:
-
-- clause 7.3 contains specific requirements for user control of audiovisual accessibility features
-- clauses 9, 10, and 11 contain requirements that may apply to the interface and controls used for activation
-- clause 11.6.1 addresses user control of documented platform accessibility features
-- clause 12.3 addresses information about accessibility features and how to use them when its precondition is met
-
-An activation path can therefore satisfy clause 5.2 and still fail another applicable requirement.
-
 ## Key Terms
 
 **Documented accessibility feature:** A feature offered to end users that can enhance accessibility and is documented.
@@ -138,6 +135,17 @@ An activation path can therefore satisfy clause 5.2 and still fail another appli
 **Supporting activation path:** A complete activation path that does not depend on a method that fails to support the specific need being assessed.
 
 ## Interpretation Notes
+
+### Related requirements
+
+Clause 5.2 should be assessed alongside other applicable requirements rather than used as a substitute for them. For example:
+
+- clause 7.3 contains specific requirements for user control of audiovisual accessibility features
+- clauses 9, 10, and 11 contain requirements that may apply to the interface and controls used for activation
+- clause 11.6.1 addresses user control of documented platform accessibility features
+- clause 12.3 addresses information about accessibility features and how to use them when its precondition is met
+
+An activation path can therefore satisfy clause 5.2 and still fail another applicable requirement.
 
 ### One method, not multiple methods by default
 

--- a/Understanding EN 301 549/5.2 Activation of Accessibility Features.md
+++ b/Understanding EN 301 549/5.2 Activation of Accessibility Features.md
@@ -38,11 +38,7 @@ The supporting method does not have to use assistive technology. It can be a bui
 
 ## Benefits
 
-People who benefit include:
-
-- people who need to activate a screen reader without relying on vision
-- people who need to activate captions without relying on hearing
-- people who need to activate voice control without relying on a gesture they cannot perform
+> **To be completed:** Add the user groups and situations that benefit from this requirement.
 
 ## Scope
 


### PR DESCRIPTION
## Problem

The clause 5.2 understanding document uses a different section order and several different top-level headings from the established clause 5.3 structure.

## Solution

Align the main section order with clause 5.3. Rename the requirement and intent sections, add a clearly marked placeholder for the missing benefits content, move scope into the agreed position, and place related requirements under interpretation notes. Preserve the existing substantive guidance.